### PR TITLE
Suppress stderr in call to ruff and add ruff formatter

### DIFF
--- a/jupyterlab_code_formatter/formatters.py
+++ b/jupyterlab_code_formatter/formatters.py
@@ -456,6 +456,8 @@ class CommandLineFormatter(BaseFormatter):
 
 
 class RuffFixFormatter(CommandLineFormatter):
+    ruff_args = ["check", "-eq", "--fix-only", "-"]
+
     @property
     def label(self) -> str:
         return f"Apply ruff Formatter"
@@ -467,7 +469,11 @@ class RuffFixFormatter(CommandLineFormatter):
             ruff_command = find_ruff_bin()
         except (ImportError, FileNotFoundError):
             ruff_command = "ruff"
-        self.command = [ruff_command, "check", "--fix-only", "-"]
+        self.command = [ruff_command, *self.ruff_args]
+
+
+class RuffFormatFormatter(RuffFixFormatter):
+    ruff_args = ["format", "-q", "-"]
 
 
 SERVER_FORMATTERS = {
@@ -477,6 +483,7 @@ SERVER_FORMATTERS = {
     "yapf": YapfFormatter(),
     "isort": IsortFormatter(),
     "ruff": RuffFixFormatter(),
+    "ruffformat": RuffFormatFormatter(),
     "formatR": FormatRFormatter(),
     "styler": StylerFormatter(),
     "scalafmt": CommandLineFormatter(command=["scalafmt", "--stdin"]),

--- a/jupyterlab_code_formatter/formatters.py
+++ b/jupyterlab_code_formatter/formatters.py
@@ -460,7 +460,7 @@ class RuffFixFormatter(CommandLineFormatter):
 
     @property
     def label(self) -> str:
-        return f"Apply ruff Formatter"
+        return "Apply ruff fix"
 
     def __init__(self):
         try:
@@ -473,6 +473,10 @@ class RuffFixFormatter(CommandLineFormatter):
 
 
 class RuffFormatFormatter(RuffFixFormatter):
+    @property
+    def label(self) -> str:
+        return "Apply ruff formatter"
+
     ruff_args = ["format", "-q", "-"]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ test = [
     "yapf",
     "rpy2",
     "importlib_metadata; python_version<'3.8'",
+    "ruff",
 ]
 
 [tool.hatch.version]

--- a/schema/settings.json
+++ b/schema/settings.json
@@ -208,6 +208,13 @@
       "additionalProperties": false,
       "type": "object"
     },
+    "ruffformat": {
+      "properties": {
+        "args": { "type": "array", "items": { "type": "string" } }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
     "formatR": {
       "properties": {
         "comment": {
@@ -407,11 +414,19 @@
       }
     },
     "ruff": {
-      "title": "Ruff Config",
-      "description": "Command line options to be passed to ruff.",
+      "title": "Ruff Check Config",
+      "description": "Command line options to be passed to ruff check.  Default is to organise imports.",
       "$ref": "#/definitions/ruff",
       "default": {
-        "args": ["--select=I"]
+        "args": ["--select=I001"]
+      }
+    },
+    "ruffformat": {
+      "title": "Ruff Format Config",
+      "description": "Command line options to be passed to ruff format.",
+      "$ref": "#/definitions/ruffformat",
+      "default": {
+        "args": []
       }
     },
     "suppressFormatterErrors": {


### PR DESCRIPTION
This PR adds the fix I suggested in #331 to ensure compatibility with ruff 0.1.0+. I've confirmed it works with version 0.1.15.

I also added the ruff formatter itself, as a substitute for black, called "ruffformat".  The formatter simply called "ruff" is for applying automatic fixes for diagnostics. For example, isort-style import sorting.