### PR TITLE
Improve safety of `RFormatter.importable`

### DIFF
--- a/jupyterlab_code_formatter/formatters.py
+++ b/jupyterlab_code_formatter/formatters.py
@@ -361,6 +361,9 @@ class RFormatter(BaseFormatter):
 
     @property
     def importable(self) -> bool:
+        if not command_exist("Rscript"):
+            return False
+
         package_location = subprocess.run(
             ["Rscript", "-e", f"cat(system.file(package='{self.package_name}'))"],
             capture_output=True,


### PR DESCRIPTION
Previously, if the system was missing Rscript, an exception would be thrown from RFormatter.importable. In some configurations, this exception caused a noisy and annoying error message, "Unable to find default formatters to use"

Fixes #352 