### PR TITLE
Update the method for determining kernel language

### DIFF
--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -98,7 +98,7 @@ export class JupyterlabNotebookCodeFormatter extends JupyterlabCodeFormatter {
     }
 
     const metadata =
-      this.notebookTracker.currentWidget.content.model!.sharedModel.metadata;
+      this.notebookTracker.currentWidget.content.model?.sharedModel?.metadata;
 
     if (!metadata) {
       return null;

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -93,38 +93,38 @@ export class JupyterlabNotebookCodeFormatter extends JupyterlabCodeFormatter {
   }
 
   private getNotebookType(): string | null {
+    // If there is no current notebook, there is nothing to do
     if (!this.notebookTracker.currentWidget) {
       return null;
     }
 
+    // first, check the notebook's metadata for language info
     const metadata =
       this.notebookTracker.currentWidget.content.model?.sharedModel?.metadata;
 
-    if (!metadata) {
-      return null;
-    }
+    if (metadata) {
+      // prefer kernelspec language
+      if (
+        metadata.kernelspec &&
+        metadata.kernelspec.language &&
+        typeof metadata.kernelspec.language === 'string'
+      ) {
+        return metadata.kernelspec.language.toLowerCase();
+      }
 
-    // prefer kernelspec language
-    if (
-      metadata.kernelspec &&
-      metadata.kernelspec.language &&
-      typeof metadata.kernelspec.language === 'string'
-    ) {
-      return metadata.kernelspec.language.toLowerCase();
-    }
-
-    // otherwise, check language info code mirror mode
-    if (metadata.language_info && metadata.language_info.codemirror_mode) {
-      const mode = metadata.language_info.codemirror_mode;
-      if (typeof mode === 'string') {
-        return mode.toLowerCase();
-      } else if (typeof mode.name === 'string') {
-        return mode.name.toLowerCase();
+      // otherwise, check language info code mirror mode
+      if (metadata.language_info && metadata.language_info.codemirror_mode) {
+        const mode = metadata.language_info.codemirror_mode;
+        if (typeof mode === 'string') {
+          return mode.toLowerCase();
+        } else if (typeof mode.name === 'string') {
+          return mode.name.toLowerCase();
+        }
       }
     }
 
-    // finally, try to get the language from the current session's kernel spec
-    const sessionContext = this.notebookTracker.currentWidget?.sessionContext;
+    // in the absence of metadata, look in the current session's kernel spec
+    const sessionContext = this.notebookTracker.currentWidget.sessionContext;
     const kernelName = sessionContext?.session?.kernel?.name;
     if (kernelName) {
       const specs = sessionContext.specsManager.specs?.kernelspecs;

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -92,7 +92,7 @@ export class JupyterlabNotebookCodeFormatter extends JupyterlabCodeFormatter {
     return codeCells;
   }
 
-  private getNotebookType() {
+  private getNotebookType(): string | null {
     if (!this.notebookTracker.currentWidget) {
       return null;
     }
@@ -120,6 +120,16 @@ export class JupyterlabNotebookCodeFormatter extends JupyterlabCodeFormatter {
         return mode.toLowerCase();
       } else if (typeof mode.name === 'string') {
         return mode.name.toLowerCase();
+      }
+    }
+
+    // finally, try to get the language from the current session's kernel spec
+    const sessionContext = this.notebookTracker.currentWidget?.sessionContext;
+    const kernelName = sessionContext?.session?.kernel?.name;
+    if (kernelName) {
+      const specs = sessionContext.specsManager.specs?.kernelspecs;
+      if (specs && kernelName in specs) {
+        return specs[kernelName]!.language;
       }
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -108,6 +108,7 @@ class JupyterLabCodeFormatter
     state: DocumentRegistry.SaveState
   ) {
     if (state === 'started' && this.config.formatOnSave) {
+      await context.sessionContext.ready;
       await this.notebookCodeFormatter.formatAllCodeCells(
         this.config,
         { saving: true },


### PR DESCRIPTION
The previous algorithm for `getNotebookType()` was based on getting the kernel spec out of the current notebook. This is a problem when format is triggered by, for example, `jupyterlab-autosave-on-focus-change`, immediately after notebook creation. In that case, the language is determined to be `null` and errors arise.

Now the `onSave()` handler waits for the `sessionContext` to be ready, then `getNotebookType()` gets the same kernel spec info from the session rather than the loaded notebook.