### PR TITLE
Fix SyntaxWarning by using a raw string in the regex pattern

### DIFF
--- a/jupyterlab_code_formatter/formatters.py
+++ b/jupyterlab_code_formatter/formatters.py
@@ -107,7 +107,7 @@ class RunScriptEscaper(BaseLineEscaper):
     unesacpe_start = len(escaped_line_start)
 
     def escape(self, line: str) -> str:
-        if re.match(pattern="run\s+\w+", string=line.lstrip()):
+        if re.match(pattern=r"run\s+\w+", string=line.lstrip()):
             line = f"{self.escaped_line_start}{line}"
         return line
 


### PR DESCRIPTION
### Problem
The previous code emitted the following warning:  
```
site-packages/jupyterlab_code_formatter/formatters.py:110: SyntaxWarning: invalid escape sequence '\s'
```

### Cause
This warning occurred because Python treats `\` as an escape character unless the string is marked as raw (using the `r""` prefix) or the escape sequence is invalid. In this case, the intention was to pass `\s` and `\w` to the regex pattern. Although the regex received the correct pattern, the warning indicates a potential issue.

### Solution
To address this, the string has been updated to use a raw string (e.g., `r"run\s+\w+"`). This approach 
- Explicitly indicates that `\` is part of the regex pattern.
- Prevents the warning.
- Makes the code more robust against new escape codes or future changes to the regex pattern.
