### PR TITLE
ruff format: don't pass -q

### DIFF
--- a/jupyterlab_code_formatter/formatters.py
+++ b/jupyterlab_code_formatter/formatters.py
@@ -480,7 +480,7 @@ class RuffFormatFormatter(RuffFixFormatter):
     def label(self) -> str:
         return "Apply ruff formatter"
 
-    ruff_args = ["format", "-q", "-"]
+    ruff_args = ["format", "-"]
 
 
 SERVER_FORMATTERS = {


### PR DESCRIPTION
`-q` suppresses errors on syntax error. Show them!

Also fixes #356. IMO both this and #367 are appropriate and can both be applied, but either one should fix the issue.