### PR TITLE
feat: improve isort configurability

### DIFF
--- a/schema/settings.json
+++ b/schema/settings.json
@@ -157,12 +157,12 @@
         }
       },
       "patternProperties": {
-        "^known_[a-z_]+": {
+        "^known_[a-zA-Z_]+": {
           "type": "array",
           "items": { "type": "string" }
         }
       },
-      "additionalProperties": false,
+      "additionalProperties": true,
       "type": "object"
     },
     "yapf": {


### PR DESCRIPTION
Add support for `isort`'s `known_OTHER` that requires sections to be written in APP_CAPS ([documentation](https://pycqa.github.io/isort/docs/configuration/options.html#known-other)).

In addition, allow additional properties to be sent to the command line (because not every option is mapped out, and to make it able to support isort forks with additional settings).